### PR TITLE
Update grok backend to use chatcompletion backend

### DIFF
--- a/massgen/backend/grok.py
+++ b/massgen/backend/grok.py
@@ -1,29 +1,28 @@
 from __future__ import annotations
 
+from openai import AsyncOpenAI
+
 """
-Grok/xAI backend implementation using OpenAI-compatible API.
-Clean implementation with only Grok-specific features.
+Grok/xAI backend is using the chat_completions backend for streaming.
+It overrides methods for Grok-specific features (Grok Live Search).
 
 ✅ TESTED: Backend works correctly with architecture
-- ✅ Grok API integration working
-- ✅ Tool message conversion compatible with Chat Completions format
+- ✅ Grok API integration working (through chat_completions)
 - ✅ Streaming functionality working correctly  
 - ✅ SingleAgent integration working
 - ✅ Error handling and pricing calculations implemented
+- ✅ Web search is working through Grok Live Search
+- ✅ MCP is working
 
 TODO for future releases:
 - Test multi-agent orchestrator integration
-- Test web search capabilities with tools
 - Validate advanced Grok-specific features
 """
 
 import os
-from typing import Dict, List, Any, AsyncGenerator, Optional
+from typing import Dict, List, Any, Optional
 from .chat_completions import ChatCompletionsBackend
-from .base import StreamChunk
 from ..logger_config import (
-    log_backend_activity,
-    log_backend_agent_message,
     log_stream_chunk,
 )
 
@@ -36,108 +35,37 @@ class GrokBackend(ChatCompletionsBackend):
         self.api_key = api_key or os.getenv("XAI_API_KEY")
         self.base_url = "https://api.x.ai/v1"
 
-    async def stream_with_tools(
-        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]], **kwargs
-    ) -> AsyncGenerator[StreamChunk, None]:
-        """Stream response using xAI's OpenAI-compatible API."""
-        # Extract agent_id for logging
-        agent_id = kwargs.get("agent_id", None)
+    def _create_openai_client(self, **kwargs) -> AsyncOpenAI:
+        """Create OpenAI client configured for xAI's Grok API."""
+        import openai
 
-        log_backend_activity(
-            self.get_provider_name(),
-            "Starting stream_with_tools",
-            {"num_messages": len(messages), "num_tools": len(tools) if tools else 0},
-            agent_id=agent_id,
-        )
+        return openai.AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
 
-        # Convert messages for Grok API compatibility
-        grok_messages = self._convert_messages_for_grok(messages)
+    def _build_base_api_params(
+        self, messages: List[Dict[str, Any]], all_params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Build base API params for xAI's Grok API."""
+        api_params = super()._build_base_api_params(messages, all_params)
 
-        # Log messages being sent
-        log_backend_agent_message(
-            agent_id or "default",
-            "SEND",
-            {"messages": grok_messages, "tools": len(tools) if tools else 0},
-            backend_name=self.get_provider_name(),
-        )
-
-        try:
-            import openai
-
-            # Use OpenAI client with xAI base URL
-            client = openai.AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
-
-            # Merge constructor config with stream kwargs (stream kwargs take priority)
-            all_params = {**self.config, **kwargs}
-
-            # Extract framework-specific parameters
-            enable_web_search = all_params.get("enable_web_search", False)
-
-            # Convert tools to Chat Completions format
-            converted_tools = (
-                self.convert_tools_to_chat_completions_format(tools) if tools else None
-            )
-
-            # Chat Completions API parameters
-            api_params = {
-                "messages": grok_messages,
-                "tools": converted_tools,
-                "stream": True,
-            }
-
-            # Direct passthrough of all parameters except those handled separately
-            excluded_params = {
-                "enable_web_search",
-                "agent_id",
-                "session_id",
-                "cwd",
-                "agent_temporary_workspace",
-            }
-            for key, value in all_params.items():
-                if key not in excluded_params and value is not None:
-                    api_params[key] = value
-
-            # Add Live Search parameters if enabled (Grok-specific)
-            if enable_web_search:
-                # Check for conflict with manually specified search_parameters
-                existing_extra = api_params.get("extra_body", {})
-                if (
+        # Add Live Search parameters if enabled (Grok-specific)
+        enable_web_search = all_params.get("enable_web_search", False)
+        if enable_web_search:
+            # Check for conflict with manually specified search_parameters
+            existing_extra = api_params.get("extra_body", {})
+            if (
                     isinstance(existing_extra, dict)
                     and "search_parameters" in existing_extra
-                ):
-                    yield StreamChunk(
-                        type="error",
-                        error="Conflict: Cannot use both 'enable_web_search: true' and manual 'extra_body.search_parameters'. Use one or the other.",
-                    )
-                    return
-
-                # Merge search_parameters into existing extra_body
-                search_params = {"mode": "auto", "return_citations": True}
-                merged_extra = existing_extra.copy()
-                merged_extra["search_parameters"] = search_params
-                api_params["extra_body"] = merged_extra
-
-            # Create stream
-            stream = await client.chat.completions.create(**api_params)
-
-            # Use base class streaming handler with logging
-            async for chunk in self.handle_chat_completions_stream_with_logging(
-                stream, enable_web_search, agent_id
             ):
-                yield chunk
+                error_message = "Conflict: Cannot use both 'enable_web_search: true' and manual 'extra_body.search_parameters'. Use one or the other."
+                log_stream_chunk('backend.grok', 'error', error_message, self.agent_id)
+                raise ValueError(error_message)
+            # Merge search_parameters into existing extra_body
+            search_params = {"mode": "auto", "return_citations": True}
+            merged_extra = existing_extra.copy()
+            merged_extra["search_parameters"] = search_params
+            api_params["extra_body"] = merged_extra
 
-        except Exception as e:
-            error_msg = f"Grok API error: {e}"
-            log_stream_chunk("backend.grok", "error", error_msg, agent_id)
-            yield StreamChunk(type="error", error=error_msg)
-        finally:
-            # Ensure the underlying HTTP client is properly closed to avoid event loop issues
-            try:
-                if hasattr(client, "aclose"):
-                    await client.aclose()
-            except Exception:
-                # Suppress cleanup errors so we don't mask primary exceptions
-                pass
+        return api_params
 
     def get_provider_name(self) -> str:
         """Get the name of this provider."""
@@ -186,43 +114,3 @@ class GrokBackend(ChatCompletionsBackend):
 
         return input_cost + output_cost
 
-    def _convert_messages_for_grok(
-        self, messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """
-        Convert messages for Grok API compatibility.
-
-        Grok expects tool call arguments as JSON strings in conversation history,
-        but returns them as objects in responses.
-        """
-        import json
-
-        converted_messages = []
-
-        for message in messages:
-            # Create a copy to avoid modifying the original
-            converted_msg = dict(message)
-
-            # Convert tool_calls arguments from objects to JSON strings
-            if message.get("role") == "assistant" and "tool_calls" in message:
-                converted_tool_calls = []
-                for tool_call in message["tool_calls"]:
-                    converted_call = dict(tool_call)
-                    if "function" in converted_call:
-                        converted_function = dict(converted_call["function"])
-                        arguments = converted_function.get("arguments")
-
-                        # Convert arguments to JSON string if it's an object
-                        if isinstance(arguments, dict):
-                            converted_function["arguments"] = json.dumps(arguments)
-                        elif arguments is None:
-                            converted_function["arguments"] = "{}"
-                        # If it's already a string, keep it as-is
-
-                        converted_call["function"] = converted_function
-                    converted_tool_calls.append(converted_call)
-                converted_msg["tool_calls"] = converted_tool_calls
-
-            converted_messages.append(converted_msg)
-
-        return converted_messages

--- a/massgen/configs/grok3_mini_mcp_example.yaml
+++ b/massgen/configs/grok3_mini_mcp_example.yaml
@@ -1,0 +1,24 @@
+# MassGen Configuration: Gemini with MCP Integration
+# Usage:
+#   uv run python -m massgen.cli --config configs/grok3_mini_mcp_example.yaml "whats the weather of Tokyo"
+agents:
+  - id: "grok3_mini_mcp_weather"
+    backend:
+      type: "grok"
+      model: "grok-3-mini"
+      mcp_servers:
+        - name: "weather"
+          type: "stdio"
+          command: "npx"
+          args: ["-y", "@fak111/weather-mcp"]
+    system_message: |
+      You are an AI assistant with access to weather information through MCP (Model Context Protocol) integration.
+
+      Weather tools are available via MCP sessions and will be called automatically by the system when needed.
+      Do not output tool call syntax or function declarations. Focus on answering the user's question clearly.
+
+      When users ask about weather conditions, forecasts, or alerts, include the location and time frame in your
+      response and provide concise, up-to-date information using the integrated tools.
+ui:
+  display_type: "rich_terminal"
+  logging_enabled: true

--- a/massgen/configs/grok3_mini_mcp_test.yaml
+++ b/massgen/configs/grok3_mini_mcp_test.yaml
@@ -1,0 +1,27 @@
+# MassGen Configuration
+# Usage:
+# uv run python -m massgen.cli --config configs/grok3_mini_mcp_test.yaml "Test the MCP tools by calling mcp_echo with text 'Hello massgen' and add_numbers with 46 and 52"
+agents:
+  - id: "grok3_mini_mcp_test"
+    backend:
+      type: "grok"
+      model: "grok-3-mini"
+      mcp_servers:
+        - name: "test_server"
+          type: "stdio"
+          command: "python"
+          args: ["-u", "-m", "massgen.tests.mcp_test_server"]
+    system_message: |
+      You are testing the MCP integration with Grok.
+
+      MCP tools from the "test_server" will be available via sessions and auto-called by the system when needed.
+      Do not output function-call syntax. Simply perform the tasks and present clear, concise results.
+
+      Tasks to verify:
+      - Echo: return the text given in the question.
+      - Add numbers: return the sum of a and b.
+      - Current time: return the current timestamp.
+
+ui:
+  display_type: "rich_terminal"
+  logging_enabled: true

--- a/massgen/configs/grok3_mini_streamable_http_test.yaml
+++ b/massgen/configs/grok3_mini_streamable_http_test.yaml
@@ -1,15 +1,15 @@
-# MassGen Configuration: gpt with Streamable HTTP MCP Integration
+# MassGen Configuration: Grok with Streamable HTTP MCP Integration
 # This configuration tests the streamable-http transport for MCP servers
 # Prerequisites:
 # 1. Start the test MCP server: python massgen/tests/test_http_mcp_server.py
 # 2. Verify server is running at http://localhost:8000/mcp
-# 3. Run: uv run python -m massgen.cli --config configs/gpt5_mini_streamable_http_test.yaml "Run a complete system check - events, birthdays, random data, and server status"
+# 3. Run: uv run python -m massgen.cli --config configs/grok3_mini_streamable_http_test.yaml "Run a complete system check - events, birthdays, random data, and server status"
 
 agents:
-  - id: "gpt5_mini_mcp_weather"
+  - id: "grok3_mini_mcp_http"
     backend:
-      type: "openai"
-      model: "gpt-5-mini"
+      type: "grok"
+      model: "grok-3-mini"
       mcp_servers:
         - name: "streamable_http_server"
           type: "streamable-http"

--- a/massgen/configs/grok3_mini_streamable_http_test.yaml
+++ b/massgen/configs/grok3_mini_streamable_http_test.yaml
@@ -39,5 +39,5 @@ agents:
       - Server status: Verify the server is healthy and reports the time.
 
 ui:
-  display_type: "simple"
+  display_type: "rich_terminal"
   logging_enabled: true

--- a/massgen/configs/grok_single_agent.yaml
+++ b/massgen/configs/grok_single_agent.yaml
@@ -1,0 +1,20 @@
+# Usage: uv run python -m massgen.cli --config grok_single_agent.yaml "List today's news in Seattle"
+agent:
+  id: "grok_agent"
+  # system_message: "You are a helpful AI assistant powered by Google Gemini."
+  backend:
+    type: "grok"
+    model: "grok-3-mini"
+    enable_web_search: false
+    extra_body:
+        search_parameters:
+           mode: "auto"                 # Search strategy (see Grok API docs for valid values)
+           return_citations: true       # Include search result citations
+           max_search_results: 3        # Max number of search results to return
+    # enable_code_execution: true
+  system_message: "You are a helpful assistant"
+
+# Display configuration
+ui:
+  display_type: "rich_terminal"
+  logging_enabled: true

--- a/massgen/configs/grok_single_agent.yaml
+++ b/massgen/configs/grok_single_agent.yaml
@@ -1,7 +1,6 @@
 # Usage: uv run python -m massgen.cli --config grok_single_agent.yaml "List today's news in Seattle"
 agent:
   id: "grok_agent"
-  # system_message: "You are a helpful AI assistant powered by Google Gemini."
   backend:
     type: "grok"
     model: "grok-3-mini"


### PR DESCRIPTION
`This template only applies to major releses (0.0.x)`

## Two-sentences summary of this release PR

Update grok to use `stream_with_tools` from chat_completions backend, so that it can use mcp.

## List of features/fixes with links to their respective sub-PRs

Grok Backend. Added a few config examples too.
